### PR TITLE
Fix refresh interval calculation in TimeframeFileInfo::needsBuild().

### DIFF
--- a/src/Files/TimeframeFileInfo.php
+++ b/src/Files/TimeframeFileInfo.php
@@ -55,7 +55,9 @@ class TimeframeFileInfo extends SingleFileInfo {
     if ($mtime < $end) {
       // The interval was still ongoing the last time the file was generated.
       // We regenerate the file if the refresh interval has passed since then.
-      return $this->refreshInterval->format('s') < time() - $mtime;
+      $t = new \DateTime();
+      $t->sub($this->refreshInterval);
+      return $t->getTimestamp() > $mtime;
     }
     return FALSE;
   }

--- a/tests/Files/TimeframeFileInfoTest.php
+++ b/tests/Files/TimeframeFileInfoTest.php
@@ -16,6 +16,7 @@ class TimeframeFileInfoTest extends \DrupalUnitTestCase {
   public function setUp() {
     parent::setUp();
     $this->path = tempnam(sys_get_temp_dir(), __FUNCTION__);
+    touch($this->path, time() - 5);
     $today = new \DateTimeImmutable((new \DateTime())->format('Y-m-d'));
     $this->todayIncludingNow = new Timeframe($today, new \DateInterval('PT25H'));
     $this->yesterday = new Timeframe($today->sub(new \DateInterval('P1D')), new \DateInterval('PT24H'));


### PR DESCRIPTION
1. DateInterval::format('s') is wrong because it always returns a literal 's'.
2. DateInterval::format('%s') doesn’t convert the interval to seconds either.