### PR TITLE
fix(webform): Manually trigger garbage collection

### DIFF
--- a/src/Exporter/WebformFormatted/Exporter.php
+++ b/src/Exporter/WebformFormatted/Exporter.php
@@ -101,6 +101,11 @@ class Exporter {
       }
       yield $submission;
       drupal_static_reset('webform_get_submission');
+      if (module_exists('webform_paymethod_select')) {
+        entity_get_controller('payment')->resetCache();
+      }
+      // Manually trigger PHP’s garbage collection to actually free the memory.
+      gc_collect_cycles();
     }
   }
 

--- a/src/Exporter/WebformGeneric/Exporter.php
+++ b/src/Exporter/WebformGeneric/Exporter.php
@@ -95,6 +95,11 @@ class Exporter {
     foreach ($result as $row) {
       yield Submission::load($row->nid, $row->sid);
       drupal_static_reset('webform_get_submission');
+      if (module_exists('webform_paymethod_select')) {
+        entity_get_controller('payment')->resetCache();
+      }
+      // Manually trigger PHP’s garbage collection to actually free the memory.
+      gc_collect_cycles();
     }
   }
 


### PR DESCRIPTION
PHP trigger garbage collection automatically when the number of defined root variables crosses a threshold. It’s possible for PHP to hit its memory limit before reaching the threshold, when big variables are defined (e.g. form submissions with much data). It’s better to trigger the garbage collection manually in these cases.